### PR TITLE
Utilize pkg-config for ncurses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ telive_receiver.o: telive_receiver.c telive_receiver.h
 	$(CC) $(CFLAGS) -c $^ `xml2-config --cflags`
 
 telive: telive.c telive.h telive_receiver.o telive_util.o
-	$(CC) $(CFLAGS) telive.c telive_receiver.o telive_util.o -o telive -lncurses `xml2-config --cflags --libs` 
+	$(CC) $(CFLAGS) telive.c telive_receiver.o telive_util.o -o telive `pkg-config ncurses --cflags --libs` `xml2-config --cflags --libs` 
 
 clean:
 	rm telive telive_receiver.o telive_util.o


### PR DESCRIPTION
Otherwise it doesn't pick the tinfo library and fails to link.